### PR TITLE
feat: show test summary on ci (circleci)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             mkdir -p $CIRCLE_TEST_REPORTS
             echo 'export PATH=$PATH:$HOME/.dotnet/tools' >> $BASH_ENV
             source $BASH_ENV && dotnet tool install -g dotnet-xunit-to-junit
-            dotnet-xunit-to-junit "results.xml" "${CIRCLE_TEST_REPORTS}/results.xml"
+            dotnet-xunit-to-junit ./src/MySQLToCsharp.Tests/results.xml "${CIRCLE_TEST_REPORTS}/results.xml"
       - store_test_results:
           path: ${CIRCLE_TEST_REPORTS}
   build-push:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - checkout
       - run: dotnet tool install -g dotnet-reportgenerator-globaltool
       - run: dotnet build -c Debug
-      - run: dotnet test -c Debug --no-build -p:CollectCoverage=true -p:CoverletOutputFormat=opencover --test-adapter-path:. --logger:"xunit;LogFilePath=results.xml
+      - run: dotnet test -c Debug --no-build -p:CollectCoverage=true -p:CoverletOutputFormat=opencover --test-adapter-path:. --logger:"xunit;LogFilePath=results.xml"
       - run: curl -s https://codecov.io/bash > codecov
       - run: chmod +x codecov
       - run: ./codecov -f ./src/MySQLToCsharp.Tests/coverage.opencover.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             mkdir -p $CIRCLE_TEST_REPORTS
             echo 'export PATH=$PATH:$HOME/.dotnet/tools' >> $BASH_ENV
             source $BASH_ENV && dotnet tool install -g dotnet-xunit-to-junit
-            dotnet xunit-to-junit "results.xml" "${CIRCLE_TEST_REPORTS}/$(basename $(pwd))/results.xml
+            dotnet-xunit-to-junit "results.xml" "${CIRCLE_TEST_REPORTS}/results.xml"
       - store_test_results:
           path: ${CIRCLE_TEST_REPORTS}
   build-push:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             source $BASH_ENV && dotnet tool install -g dotnet-xunit-to-junit
             dotnet-xunit-to-junit ./src/MySQLToCsharp.Tests/results.xml "${CIRCLE_TEST_REPORTS}/results.xml"
       - store_test_results:
-          path: ${CIRCLE_TEST_REPORTS}
+          path: /workspace/circleci-test-results
   build-push:
     executor: dotnet
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,12 @@ jobs:
       - run: curl -s https://codecov.io/bash > codecov
       - run: chmod +x codecov
       - run: ./codecov -f ./src/MySQLToCsharp.Tests/coverage.opencover.xml
-      - run: |
-        mkdir -p $CIRCLE_TEST_REPORTS
-        echo 'export PATH=$PATH:$HOME/.dotnet/tools' >> $BASH_ENV
-        source $BASH_ENV && dotnet tool install -g dotnet-xunit-to-junit
-        dotnet xunit-to-junit "results.xml" "${CIRCLE_TEST_REPORTS}/$(basename $(pwd))/results.xml
+      - run:
+          command: |
+            mkdir -p $CIRCLE_TEST_REPORTS
+            echo 'export PATH=$PATH:$HOME/.dotnet/tools' >> $BASH_ENV
+            source $BASH_ENV && dotnet tool install -g dotnet-xunit-to-junit
+            dotnet xunit-to-junit "results.xml" "${CIRCLE_TEST_REPORTS}/$(basename $(pwd))/results.xml
   build-push:
     executor: dotnet
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ jobs:
             echo 'export PATH=$PATH:$HOME/.dotnet/tools' >> $BASH_ENV
             source $BASH_ENV && dotnet tool install -g dotnet-xunit-to-junit
             dotnet xunit-to-junit "results.xml" "${CIRCLE_TEST_REPORTS}/$(basename $(pwd))/results.xml
+      - store_test_results:
+          path: ${CIRCLE_TEST_REPORTS}
   build-push:
     executor: dotnet
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ executors:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
       NUGET_XMLDOC_MODE: skip
       BUILD_CONFIG: Release
+      CIRCLE_TEST_REPORTS: /workspace/circleci-test-results
   dotnet3:
     docker:
       - image: mcr.microsoft.com/dotnet/core/sdk:3.0
@@ -23,10 +24,15 @@ jobs:
       - checkout
       - run: dotnet tool install -g dotnet-reportgenerator-globaltool
       - run: dotnet build -c Debug
-      - run: dotnet test -c Debug --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+      - run: dotnet test -c Debug --no-build -p:CollectCoverage=true -p:CoverletOutputFormat=opencover --test-adapter-path:. --logger:"xunit;LogFilePath=results.xml
       - run: curl -s https://codecov.io/bash > codecov
       - run: chmod +x codecov
       - run: ./codecov -f ./src/MySQLToCsharp.Tests/coverage.opencover.xml
+      - run: |
+        mkdir -p $CIRCLE_TEST_REPORTS
+        echo 'export PATH=$PATH:$HOME/.dotnet/tools' >> $BASH_ENV
+        source $BASH_ENV && dotnet tool install -g dotnet-xunit-to-junit
+        dotnet xunit-to-junit "results.xml" "${CIRCLE_TEST_REPORTS}/$(basename $(pwd))/results.xml
   build-push:
     executor: dotnet
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,5 @@ MigrationBackup/
 
 # custom
 launchSettings.json
+coverage.opencover.xml
+results.xml

--- a/src/MySQLToCsharp.Tests/MySQLToCsharp.Tests.csproj
+++ b/src/MySQLToCsharp.Tests/MySQLToCsharp.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="RandomFixtureKit" Version="1.0.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## TL;DR

Show Test Failed summary on circleci.

CircleCI uses junit style test summary.

## Sample

![image](https://user-images.githubusercontent.com/3856350/63198611-35c20780-c0b6-11e9-8cfe-8b3afce87732.png)

## TODO

- [x] Add XunitXml.TestLogger to generate xml
- [x] generate xml result on dotnet test with `--test-adapter-path:. --logger:"xunit;LogFilePath=results.xml"` and upload.
- [x] confirm wotk on circleci

## ref

> https://circleci.com/docs/2.0/configuration-reference/#store_test_results