### PR TITLE
feat: ignore eol when generate

### DIFF
--- a/src/MySQLToCsharp/Generator.cs
+++ b/src/MySQLToCsharp/Generator.cs
@@ -15,11 +15,13 @@ namespace MySQLToCsharp
         public ITypeConverter TypeConverter { get; }
 
         private readonly Encoding encoding;
+        private readonly bool ignoreEol;
 
-        public Generator(bool addbom, ITypeConverter typeConverter)
+        public Generator(ITypeConverter typeConverter, bool addbom = false, bool ignoreeol = true)
         {
             TypeConverter = typeConverter;
             encoding = new UTF8Encoding(addbom);
+            ignoreEol = ignoreeol;
         }
 
         public void Save(string className, string text, string outputFolderPath, bool dry)
@@ -40,12 +42,24 @@ namespace MySQLToCsharp
                     Console.WriteLine($"[-] skipped: {fileName} (no change)");
                     return;
                 }
+                else if (ignoreEol && Equals(text, current))
+                {
+                    Console.WriteLine($"[-] skipped: {fileName} (ignore eol changed)");
+                    return;
+                }
             }
             Console.WriteLine($"[o] generate: {fileName}");
             if (!dry)
             {
                 File.WriteAllText(outputFile, text, encoding);
             }
+        }
+
+        private bool Equals(string lh, string rh)
+        {
+            var l = lh.Replace("\r\n", "").Replace("\n", "");
+            var r = rh.Replace("\r\n", "").Replace("\n", "");
+            return l == r;
         }
 
         public string Generate(string @namespace, string className, MySqlTableDefinition table, ITypeConverter typeConverter)

--- a/src/MySQLToCsharp/Program.cs
+++ b/src/MySQLToCsharp/Program.cs
@@ -25,6 +25,7 @@ namespace MySQLToCsharp
             [Option('o', Description = "output directory path of generated C# class file")]string output,
             [Option('n', Description = "namespace to write")]string @namespace,
             [Option('c', Description = "converter name to use")]string converter = defaultConverter,
+            [Option(Description = "true to ignore eol")]bool ignoreeol = true,
             [Option(Description = "true to add bom")]bool addbom = false,
             [Option(Description = "true to dry-run")]bool dry = false,
             [Option(Description = "executionid to detect execution")]string executionid = nameof(Query))
@@ -34,7 +35,7 @@ namespace MySQLToCsharp
 
             var table = Parser.FromQuery(input);
             var resolvedConverter = TypeConverterResolver.Resolve(converter);
-            var generator = new Generator(addbom, resolvedConverter);
+            var generator = new Generator(resolvedConverter, addbom, ignoreeol);
 
             var className = Generator.GetClassName(table.Name);
             var generated =generator.Generate(@namespace, className, table, resolvedConverter);
@@ -49,6 +50,7 @@ namespace MySQLToCsharp
             [Option('o', Description = "output directory path of generated C# class file")]string output,
             [Option('n', Description = "namespace to write")]string @namespace,
             [Option('c', Description = "converter name to use")]string converter = defaultConverter,
+            [Option(Description = "true to ignore eol")]bool ignoreeol = true,
             [Option(Description = "true to add bom")]bool addbom = false,
             [Option(Description = "true to dry-run")]bool dry = false,
             [Option(Description = "executionid to detect execution")]string executionid = nameof(Query))
@@ -58,7 +60,7 @@ namespace MySQLToCsharp
 
             var table = Parser.FromFile(input, false);
             var resolvedConverter = TypeConverterResolver.Resolve(converter);
-            var generator = new Generator(addbom, resolvedConverter);
+            var generator = new Generator(resolvedConverter, addbom, ignoreeol);
 
             var className = Generator.GetClassName(table.Name);
             var generated = generator.Generate(@namespace, className, table, resolvedConverter);
@@ -73,6 +75,7 @@ namespace MySQLToCsharp
             [Option('o', Description = "output directory path of generated C# class files")]string output,
             [Option('n', Description = "namespace to write")]string @namespace,
             [Option('c', Description = "converter name to use")]string converter = defaultConverter,
+            [Option(Description = "true to ignore eol")]bool ignoreeol = true,
             [Option(Description = "true to add bom")]bool addbom = false,
             [Option(Description = "true to dry-run")]bool dry = false,
             [Option(Description = "executionid to detect execution")]string executionid = nameof(Query))
@@ -82,7 +85,7 @@ namespace MySQLToCsharp
 
             var tables = Parser.FromFolder(input, false).ToArray();
             var resolvedConverter = TypeConverterResolver.Resolve(converter);
-            var generator = new Generator(addbom, resolvedConverter);
+            var generator = new Generator(resolvedConverter, addbom, ignoreeol);
             foreach (var table in tables)
             {
                 var className = Generator.GetClassName(table.Name);


### PR DESCRIPTION
When you generate .cs on Windows, eol would be `\r\n`.
However it's `\n` on Linux and macOS.

offer `ignoreeol` option to skip save when eol differs.