### PR TITLE
Fix for Missed opportunity to use Where

### DIFF
--- a/src/MySQLToCsharp.Parser/MySqlDefinitions.cs
+++ b/src/MySQLToCsharp.Parser/MySqlDefinitions.cs
@@ -364,10 +364,8 @@ namespace MySQLToCsharp
         private void AddKeyReferenceOnColumnCore(MySqlColumnDefinition[] columnDefinitions, Action<MySqlColumnDefinition> mapper)
         {
             var indexKeyNames = this.Indexes.Select(x => x.IndexKey).ToArray();
-            foreach (var column in columnDefinitions)
+            foreach (var column in columnDefinitions.Where(column => indexKeyNames.Contains(column.Name)))
             {
-                if (!indexKeyNames.Contains(column.Name)) continue;
-
                 // column -> key reference mapper
                 mapper(column);
 


### PR DESCRIPTION
In general terms, the fix is to make the filtering of `columnDefinitions` explicit by using LINQ’s `Where` method before iterating, instead of iterating all elements and skipping some with `continue`. This both addresses the CodeQL warning and makes the intent clearer: only columns whose names are present in `indexKeyNames` are processed.

The best way to fix this without changing existing functionality is:
- Replace the `foreach (var column in columnDefinitions)` loop plus the `if (!indexKeyNames.Contains(column.Name)) continue;` guard with a `foreach` over a filtered sequence, such as `foreach (var column in columnDefinitions.Where(column => indexKeyNames.Contains(column.Name)))`.
- Keep the contents of the loop body (the `mapper(column)` call and the inner `foreach` over `this.Indexes.Where(...)`) unchanged.

To implement this:
- Modify `AddKeyReferenceOnColumnCore` in `src/MySQLToCsharp.Parser/MySqlDefinitions.cs`, around lines 364–379.
- Because the snippet already uses LINQ methods (`Select`, `Where`) on `this.Indexes`, the necessary `using System.Linq;` is presumably already present elsewhere in the file or project; if it is not, add it at the top of this file. We will not change any other behavior or structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._